### PR TITLE
Add breaks to registration form

### DIFF
--- a/src/bayestourney/views/auth/register.html
+++ b/src/bayestourney/views/auth/register.html
@@ -8,12 +8,16 @@
   <form method="post">
     <label for="username">Username</label>
     <input name="username" id="username" required>
+    <br><br>
     <label for="email">Email</label>
     <input name="email" id="email" required>
+    <br><br>
     <label for="password">Password</label>
     <input type="password" name="password" id="password" required>
+    <br><br>
     <label for="verify_password">Verify Password</label>
     <input type="password" name="verify_password" id="verify_password" required>
+    <br><br>
     <input type="submit" value="Register">
   </form>
 {% endblock %}


### PR DESCRIPTION
Add <br><br> to registration form, because the labels were folding badly on small screens.